### PR TITLE
Upgrade civix file for PHP8.0 compatibility

### DIFF
--- a/civizoom.civix.php
+++ b/civizoom.civix.php
@@ -7,9 +7,9 @@
  * extension.
  */
 class CRM_Civizoom_ExtensionUtil {
-  const SHORT_NAME = "civizoom";
-  const LONG_NAME = "biz.lcdservices.civizoom";
-  const CLASS_PREFIX = "CRM_Civizoom";
+  const SHORT_NAME = 'civizoom';
+  const LONG_NAME = 'biz.lcdservices.civizoom';
+  const CLASS_PREFIX = 'CRM_Civizoom';
 
   /**
    * Translate a string using the extension's domain.
@@ -24,9 +24,9 @@ class CRM_Civizoom_ExtensionUtil {
    *   Translated text.
    * @see ts
    */
-  public static function ts($text, $params = array()) {
+  public static function ts($text, $params = []) {
     if (!array_key_exists('domain', $params)) {
-      $params['domain'] = array(self::LONG_NAME, NULL);
+      $params['domain'] = [self::LONG_NAME, NULL];
     }
     return ts($text, $params);
   }
@@ -79,10 +79,17 @@ class CRM_Civizoom_ExtensionUtil {
 
 use CRM_Civizoom_ExtensionUtil as E;
 
+function _civizoom_civix_mixin_polyfill() {
+  if (!class_exists('CRM_Extension_MixInfo')) {
+    $polyfill = __DIR__ . '/mixin/polyfill.php';
+    (require $polyfill)(E::LONG_NAME, E::SHORT_NAME, E::path());
+  }
+}
+
 /**
  * (Delegated) Implements hook_civicrm_config().
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_config
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_config
  */
 function _civizoom_civix_civicrm_config(&$config = NULL) {
   static $configured = FALSE;
@@ -91,56 +98,45 @@ function _civizoom_civix_civicrm_config(&$config = NULL) {
   }
   $configured = TRUE;
 
-  $template =& CRM_Core_Smarty::singleton();
+  $template = CRM_Core_Smarty::singleton();
 
-  $extRoot = dirname(__FILE__) . DIRECTORY_SEPARATOR;
+  $extRoot = __DIR__ . DIRECTORY_SEPARATOR;
   $extDir = $extRoot . 'templates';
 
   if (is_array($template->template_dir)) {
     array_unshift($template->template_dir, $extDir);
   }
   else {
-    $template->template_dir = array($extDir, $template->template_dir);
+    $template->template_dir = [$extDir, $template->template_dir];
   }
 
   $include_path = $extRoot . PATH_SEPARATOR . get_include_path();
   set_include_path($include_path);
-}
-
-/**
- * (Delegated) Implements hook_civicrm_xmlMenu().
- *
- * @param $files array(string)
- *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_xmlMenu
- */
-function _civizoom_civix_civicrm_xmlMenu(&$files) {
-  foreach (_civizoom_civix_glob(__DIR__ . '/xml/Menu/*.xml') as $file) {
-    $files[] = $file;
-  }
+  _civizoom_civix_mixin_polyfill();
 }
 
 /**
  * Implements hook_civicrm_install().
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_install
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_install
  */
 function _civizoom_civix_civicrm_install() {
   _civizoom_civix_civicrm_config();
   if ($upgrader = _civizoom_civix_upgrader()) {
     $upgrader->onInstall();
   }
+  _civizoom_civix_mixin_polyfill();
 }
 
 /**
  * Implements hook_civicrm_postInstall().
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_postInstall
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_postInstall
  */
 function _civizoom_civix_civicrm_postInstall() {
   _civizoom_civix_civicrm_config();
   if ($upgrader = _civizoom_civix_upgrader()) {
-    if (is_callable(array($upgrader, 'onPostInstall'))) {
+    if (is_callable([$upgrader, 'onPostInstall'])) {
       $upgrader->onPostInstall();
     }
   }
@@ -149,7 +145,7 @@ function _civizoom_civix_civicrm_postInstall() {
 /**
  * Implements hook_civicrm_uninstall().
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_uninstall
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_uninstall
  */
 function _civizoom_civix_civicrm_uninstall() {
   _civizoom_civix_civicrm_config();
@@ -161,27 +157,28 @@ function _civizoom_civix_civicrm_uninstall() {
 /**
  * (Delegated) Implements hook_civicrm_enable().
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_enable
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_enable
  */
 function _civizoom_civix_civicrm_enable() {
   _civizoom_civix_civicrm_config();
   if ($upgrader = _civizoom_civix_upgrader()) {
-    if (is_callable(array($upgrader, 'onEnable'))) {
+    if (is_callable([$upgrader, 'onEnable'])) {
       $upgrader->onEnable();
     }
   }
+  _civizoom_civix_mixin_polyfill();
 }
 
 /**
  * (Delegated) Implements hook_civicrm_disable().
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_disable
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_disable
  * @return mixed
  */
 function _civizoom_civix_civicrm_disable() {
   _civizoom_civix_civicrm_config();
   if ($upgrader = _civizoom_civix_upgrader()) {
-    if (is_callable(array($upgrader, 'onDisable'))) {
+    if (is_callable([$upgrader, 'onDisable'])) {
       $upgrader->onDisable();
     }
   }
@@ -193,10 +190,11 @@ function _civizoom_civix_civicrm_disable() {
  * @param $op string, the type of operation being performed; 'check' or 'enqueue'
  * @param $queue CRM_Queue_Queue, (for 'enqueue') the modifiable list of pending up upgrade tasks
  *
- * @return mixed  based on op. for 'check', returns array(boolean) (TRUE if upgrades are pending)
- *                for 'enqueue', returns void
+ * @return mixed
+ *   based on op. for 'check', returns array(boolean) (TRUE if upgrades are pending)
+ *   for 'enqueue', returns void
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_upgrade
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_upgrade
  */
 function _civizoom_civix_civicrm_upgrade($op, CRM_Queue_Queue $queue = NULL) {
   if ($upgrader = _civizoom_civix_upgrader()) {
@@ -217,138 +215,6 @@ function _civizoom_civix_upgrader() {
 }
 
 /**
- * Search directory tree for files which match a glob pattern
- *
- * Note: Dot-directories (like "..", ".git", or ".svn") will be ignored.
- * Note: In Civi 4.3+, delegate to CRM_Utils_File::findFiles()
- *
- * @param $dir string, base dir
- * @param $pattern string, glob pattern, eg "*.txt"
- * @return array(string)
- */
-function _civizoom_civix_find_files($dir, $pattern) {
-  if (is_callable(array('CRM_Utils_File', 'findFiles'))) {
-    return CRM_Utils_File::findFiles($dir, $pattern);
-  }
-
-  $todos = array($dir);
-  $result = array();
-  while (!empty($todos)) {
-    $subdir = array_shift($todos);
-    foreach (_civizoom_civix_glob("$subdir/$pattern") as $match) {
-      if (!is_dir($match)) {
-        $result[] = $match;
-      }
-    }
-    if ($dh = opendir($subdir)) {
-      while (FALSE !== ($entry = readdir($dh))) {
-        $path = $subdir . DIRECTORY_SEPARATOR . $entry;
-        if ($entry{0} == '.') {
-        }
-        elseif (is_dir($path)) {
-          $todos[] = $path;
-        }
-      }
-      closedir($dh);
-    }
-  }
-  return $result;
-}
-/**
- * (Delegated) Implements hook_civicrm_managed().
- *
- * Find any *.mgd.php files, merge their content, and return.
- *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_managed
- */
-function _civizoom_civix_civicrm_managed(&$entities) {
-  $mgdFiles = _civizoom_civix_find_files(__DIR__, '*.mgd.php');
-  foreach ($mgdFiles as $file) {
-    $es = include $file;
-    foreach ($es as $e) {
-      if (empty($e['module'])) {
-        $e['module'] = E::LONG_NAME;
-      }
-      if (empty($e['params']['version'])) {
-        $e['params']['version'] = '3';
-      }
-      $entities[] = $e;
-    }
-  }
-}
-
-/**
- * (Delegated) Implements hook_civicrm_caseTypes().
- *
- * Find any and return any files matching "xml/case/*.xml"
- *
- * Note: This hook only runs in CiviCRM 4.4+.
- *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_caseTypes
- */
-function _civizoom_civix_civicrm_caseTypes(&$caseTypes) {
-  if (!is_dir(__DIR__ . '/xml/case')) {
-    return;
-  }
-
-  foreach (_civizoom_civix_glob(__DIR__ . '/xml/case/*.xml') as $file) {
-    $name = preg_replace('/\.xml$/', '', basename($file));
-    if ($name != CRM_Case_XMLProcessor::mungeCaseType($name)) {
-      $errorMessage = sprintf("Case-type file name is malformed (%s vs %s)", $name, CRM_Case_XMLProcessor::mungeCaseType($name));
-      CRM_Core_Error::fatal($errorMessage);
-      // throw new CRM_Core_Exception($errorMessage);
-    }
-    $caseTypes[$name] = array(
-      'module' => E::LONG_NAME,
-      'name' => $name,
-      'file' => $file,
-    );
-  }
-}
-
-/**
- * (Delegated) Implements hook_civicrm_angularModules().
- *
- * Find any and return any files matching "ang/*.ang.php"
- *
- * Note: This hook only runs in CiviCRM 4.5+.
- *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_angularModules
- */
-function _civizoom_civix_civicrm_angularModules(&$angularModules) {
-  if (!is_dir(__DIR__ . '/ang')) {
-    return;
-  }
-
-  $files = _civizoom_civix_glob(__DIR__ . '/ang/*.ang.php');
-  foreach ($files as $file) {
-    $name = preg_replace(':\.ang\.php$:', '', basename($file));
-    $module = include $file;
-    if (empty($module['ext'])) {
-      $module['ext'] = E::LONG_NAME;
-    }
-    $angularModules[$name] = $module;
-  }
-}
-
-/**
- * Glob wrapper which is guaranteed to return an array.
- *
- * The documentation for glob() says, "On some systems it is impossible to
- * distinguish between empty match and an error." Anecdotally, the return
- * result for an empty match is sometimes array() and sometimes FALSE.
- * This wrapper provides consistency.
- *
- * @link http://php.net/glob
- * @param string $pattern
- * @return array, possibly empty
- */
-function _civizoom_civix_glob($pattern) {
-  $result = glob($pattern);
-  return is_array($result) ? $result : array();
-}
-
-/**
  * Inserts a navigation menu item at a given place in the hierarchy.
  *
  * @param array $menu - menu hierarchy
@@ -356,16 +222,18 @@ function _civizoom_civix_glob($pattern) {
  *    'Mailing', or 'Administer/System Settings'
  * @param array $item - the item to insert (parent/child attributes will be
  *    filled for you)
+ *
+ * @return bool
  */
 function _civizoom_civix_insert_navigation_menu(&$menu, $path, $item) {
   // If we are done going down the path, insert menu
   if (empty($path)) {
-    $menu[] = array(
-      'attributes' => array_merge(array(
+    $menu[] = [
+      'attributes' => array_merge([
         'label'      => CRM_Utils_Array::value('name', $item),
         'active'     => 1,
-      ), $item),
-    );
+      ], $item),
+    ];
     return TRUE;
   }
   else {
@@ -376,9 +244,9 @@ function _civizoom_civix_insert_navigation_menu(&$menu, $path, $item) {
     foreach ($menu as $key => &$entry) {
       if ($entry['attributes']['name'] == $first) {
         if (!isset($entry['child'])) {
-          $entry['child'] = array();
+          $entry['child'] = [];
         }
-        $found = _civizoom_civix_insert_navigation_menu($entry['child'], implode('/', $path), $item, $key);
+        $found = _civizoom_civix_insert_navigation_menu($entry['child'], implode('/', $path), $item);
       }
     }
     return $found;
@@ -389,7 +257,7 @@ function _civizoom_civix_insert_navigation_menu(&$menu, $path, $item) {
  * (Delegated) Implements hook_civicrm_navigationMenu().
  */
 function _civizoom_civix_navigationMenu(&$nodes) {
-  if (!is_callable(array('CRM_Core_BAO_Navigation', 'fixNavigationMenu'))) {
+  if (!is_callable(['CRM_Core_BAO_Navigation', 'fixNavigationMenu'])) {
     _civizoom_civix_fixNavigationMenu($nodes);
   }
 }
@@ -429,32 +297,12 @@ function _civizoom_civix_fixNavigationMenuItems(&$nodes, &$maxNavID, $parentID) 
 }
 
 /**
- * (Delegated) Implements hook_civicrm_alterSettingsFolders().
- *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_alterSettingsFolders
- */
-function _civizoom_civix_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
-  static $configured = FALSE;
-  if ($configured) {
-    return;
-  }
-  $configured = TRUE;
-
-  $settingsDir = __DIR__ . DIRECTORY_SEPARATOR . 'settings';
-  if (is_dir($settingsDir) && !in_array($settingsDir, $metaDataFolders)) {
-    $metaDataFolders[] = $settingsDir;
-  }
-}
-
-/**
  * (Delegated) Implements hook_civicrm_entityTypes().
  *
  * Find any *.entityType.php files, merge their content, and return.
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_entityTypes
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_entityTypes
  */
-
 function _civizoom_civix_civicrm_entityTypes(&$entityTypes) {
-  $entityTypes = array_merge($entityTypes, array (
-  ));
+  $entityTypes = array_merge($entityTypes, []);
 }

--- a/civizoom.php
+++ b/civizoom.php
@@ -13,15 +13,6 @@ function civizoom_civicrm_config(&$config) {
 }
 
 /**
- * Implements hook_civicrm_xmlMenu().
- *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_xmlMenu
- */
-function civizoom_civicrm_xmlMenu(&$files) {
-  _civizoom_civix_civicrm_xmlMenu($files);
-}
-
-/**
  * Implements hook_civicrm_install().
  *
  * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_install
@@ -73,54 +64,6 @@ function civizoom_civicrm_disable() {
  */
 function civizoom_civicrm_upgrade($op, CRM_Queue_Queue $queue = NULL) {
   return _civizoom_civix_civicrm_upgrade($op, $queue);
-}
-
-/**
- * Implements hook_civicrm_managed().
- *
- * Generate a list of entities to create/deactivate/delete when this module
- * is installed, disabled, uninstalled.
- *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_managed
- */
-function civizoom_civicrm_managed(&$entities) {
-  _civizoom_civix_civicrm_managed($entities);
-}
-
-/**
- * Implements hook_civicrm_caseTypes().
- *
- * Generate a list of case-types.
- *
- * Note: This hook only runs in CiviCRM 4.4+.
- *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_caseTypes
- */
-function civizoom_civicrm_caseTypes(&$caseTypes) {
-  _civizoom_civix_civicrm_caseTypes($caseTypes);
-}
-
-/**
- * Implements hook_civicrm_angularModules().
- *
- * Generate a list of Angular modules.
- *
- * Note: This hook only runs in CiviCRM 4.5+. It may
- * use features only available in v4.6+.
- *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_angularModules
- */
-function civizoom_civicrm_angularModules(&$angularModules) {
-  _civizoom_civix_civicrm_angularModules($angularModules);
-}
-
-/**
- * Implements hook_civicrm_alterSettingsFolders().
- *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_alterSettingsFolders
- */
-function civizoom_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
-  _civizoom_civix_civicrm_alterSettingsFolders($metaDataFolders);
 }
 
 /**

--- a/info.xml
+++ b/info.xml
@@ -20,9 +20,14 @@
   <compatibility>
     <ver>5.29</ver>
   </compatibility>
-  <comments></comments>
-  <comments></comments>
+  <comments/>
+  <comments/>
   <civix>
     <namespace>CRM/Civizoom</namespace>
+    <format>22.05.2</format>
   </civix>
+  <mixins>
+    <mixin>menu-xml@1.0.0</mixin>
+    <mixin>setting-php@1.0.0</mixin>
+  </mixins>
 </extension>

--- a/mixin/menu-xml@1.0.0.mixin.php
+++ b/mixin/menu-xml@1.0.0.mixin.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * Auto-register "xml/Menu/*.xml" files.
+ *
+ * @mixinName menu-xml
+ * @mixinVersion 1.0.0
+ *
+ * @param CRM_Extension_MixInfo $mixInfo
+ *   On newer deployments, this will be an instance of MixInfo. On older deployments, Civix may polyfill with a work-a-like.
+ * @param \CRM_Extension_BootCache $bootCache
+ *   On newer deployments, this will be an instance of MixInfo. On older deployments, Civix may polyfill with a work-a-like.
+ */
+return function ($mixInfo, $bootCache) {
+
+  /**
+   * @param \Civi\Core\Event\GenericHookEvent $e
+   * @see CRM_Utils_Hook::xmlMenu()
+   */
+  Civi::dispatcher()->addListener('hook_civicrm_xmlMenu', function ($e) use ($mixInfo) {
+    if (!$mixInfo->isActive()) {
+      return;
+    }
+
+    $files = (array) glob($mixInfo->getPath('xml/Menu/*.xml'));
+    foreach ($files as $file) {
+      $e->files[] = $file;
+    }
+  });
+
+};

--- a/mixin/polyfill.php
+++ b/mixin/polyfill.php
@@ -1,0 +1,101 @@
+<?php
+
+/**
+ * When deploying on systems that lack mixin support, fake it.
+ *
+ * @mixinFile polyfill.php
+ *
+ * This polyfill does some (persnickity) deduplication, but it doesn't allow upgrades or shipping replacements in core.
+ *
+ * Note: The polyfill.php is designed to be copied into extensions for interoperability. Consequently, this file is
+ * not used 'live' by `civicrm-core`. However, the file does need a canonical home, and it's convenient to keep it
+ * adjacent to the actual mixin files.
+ *
+ * @param string $longName
+ * @param string $shortName
+ * @param string $basePath
+ */
+return function ($longName, $shortName, $basePath) {
+  // Construct imitations of the mixin services. These cannot work as well (e.g. with respect to
+  // number of file-reads, deduping, upgrading)... but they should be OK for a few months while
+  // the mixin services become available.
+
+  // List of active mixins; deduped by version
+  $mixinVers = [];
+  foreach ((array) glob($basePath . '/mixin/*.mixin.php') as $f) {
+    [$name, $ver] = explode('@', substr(basename($f), 0, -10));
+    if (!isset($mixinVers[$name]) || version_compare($ver, $mixinVers[$name], '>')) {
+      $mixinVers[$name] = $ver;
+    }
+  }
+  $mixins = [];
+  foreach ($mixinVers as $name => $ver) {
+    $mixins[] = "$name@$ver";
+  }
+
+  // Imitate CRM_Extension_MixInfo.
+  $mixInfo = new class() {
+
+    /**
+     * @var string
+     */
+    public $longName;
+
+    /**
+     * @var string
+     */
+    public $shortName;
+
+    public $_basePath;
+
+    public function getPath($file = NULL) {
+      return $this->_basePath . ($file === NULL ? '' : (DIRECTORY_SEPARATOR . $file));
+    }
+
+    public function isActive() {
+      return \CRM_Extension_System::singleton()->getMapper()->isActiveModule($this->shortName);
+    }
+
+  };
+  $mixInfo->longName = $longName;
+  $mixInfo->shortName = $shortName;
+  $mixInfo->_basePath = $basePath;
+
+  // Imitate CRM_Extension_BootCache.
+  $bootCache = new class() {
+
+    public function define($name, $callback) {
+      $envId = \CRM_Core_Config_Runtime::getId();
+      $oldExtCachePath = \Civi::paths()->getPath("[civicrm.compile]/CachedExtLoader.{$envId}.php");
+      $stat = stat($oldExtCachePath);
+      $file = Civi::paths()->getPath('[civicrm.compile]/CachedMixin.' . md5($name . ($stat['mtime'] ?? 0)) . '.php');
+      if (file_exists($file)) {
+        return include $file;
+      }
+      else {
+        $data = $callback();
+        file_put_contents($file, '<' . "?php\nreturn " . var_export($data, 1) . ';');
+        return $data;
+      }
+    }
+
+  };
+
+  // Imitate CRM_Extension_MixinLoader::run()
+  // Parse all live mixins before trying to scan any classes.
+  global $_CIVIX_MIXIN_POLYFILL;
+  foreach ($mixins as $mixin) {
+    // If the exact same mixin is defined by multiple exts, just use the first one.
+    if (!isset($_CIVIX_MIXIN_POLYFILL[$mixin])) {
+      $_CIVIX_MIXIN_POLYFILL[$mixin] = include_once $basePath . '/mixin/' . $mixin . '.mixin.php';
+    }
+  }
+  foreach ($mixins as $mixin) {
+    // If there's trickery about installs/uninstalls/resets, then we may need to register a second time.
+    if (!isset(\Civi::$statics[__FUNCTION__][$mixin])) {
+      \Civi::$statics[__FUNCTION__][$mixin] = 1;
+      $func = $_CIVIX_MIXIN_POLYFILL[$mixin];
+      $func($mixInfo, $bootCache);
+    }
+  }
+};

--- a/mixin/setting-php@1.0.0.mixin.php
+++ b/mixin/setting-php@1.0.0.mixin.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * Auto-register "settings/*.setting.php" files.
+ *
+ * @mixinName setting-php
+ * @mixinVersion 1.0.0
+ *
+ * @param CRM_Extension_MixInfo $mixInfo
+ *   On newer deployments, this will be an instance of MixInfo. On older deployments, Civix may polyfill with a work-a-like.
+ * @param \CRM_Extension_BootCache $bootCache
+ *   On newer deployments, this will be an instance of MixInfo. On older deployments, Civix may polyfill with a work-a-like.
+ */
+return function ($mixInfo, $bootCache) {
+
+  /**
+   * @param \Civi\Core\Event\GenericHookEvent $e
+   * @see CRM_Utils_Hook::alterSettingsFolders()
+   */
+  Civi::dispatcher()->addListener('hook_civicrm_alterSettingsFolders', function ($e) use ($mixInfo) {
+    // When deactivating on a polyfill/pre-mixin system, listeners may not cleanup automatically.
+    if (!$mixInfo->isActive()) {
+      return;
+    }
+
+    $settingsDir = $mixInfo->getPath('settings');
+    if (!in_array($settingsDir, $e->settingsFolders) && is_dir($settingsDir)) {
+      $e->settingsFolders[] = $settingsDir;
+    }
+  });
+
+};


### PR DESCRIPTION
On PHP8.0 the following depreciation message is displayed:
<img width="669" alt="Screenshot 2022-09-26 at 07 04 43" src="https://user-images.githubusercontent.com/85277674/192204537-0b4b2e9b-b4e1-4f69-bd76-5090b3cc2691.png">

To resolve this error, we upgrade the civic file using the command: `civix upgrade`

Civix version `22.05.2`
